### PR TITLE
Update Episerver packages, target IndexingService to .NET 7 

### DIFF
--- a/.github/workflows/ci-client.yml
+++ b/.github/workflows/ci-client.yml
@@ -23,19 +23,20 @@ jobs:
       versionSuffix: ${{ github.ref == 'refs/heads/develop' && 'pre-' ||  'ci-' }}${{github.RUN_NUMBER }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Setup .NET Core @ Latest
-        uses: actions/setup-dotnet@v1
+        uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
         with:
+          dotnet-version: '7.0.x'
           source-url: https://nuget.pkg.github.com/${{ github.repository_owner }}/index.json
         env:
           NUGET_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
-      
+
       - name: Restore
         run: dotnet restore
       - name: Build (Release version)
         if:  ${{ github.ref == 'refs/heads/main' }}
-        run: dotnet build --no-restore --configuration $env:buildConfiguration 
+        run: dotnet build --no-restore --configuration $env:buildConfiguration
       - name: Build (Pre-Release version)
         if:  ${{ github.ref != 'refs/heads/main' }}
         run: dotnet build --no-restore --configuration $env:buildConfiguration --version-suffix $env:versionSuffix

--- a/.github/workflows/ci-service.yml
+++ b/.github/workflows/ci-service.yml
@@ -10,7 +10,7 @@ on:
     #  - 'src/EPiServer.Search.IndexingService/**'
     #  - 'test/EPiServer.Search.IndexingService.Test/**'
     #  - 'docker-compose.yml'
-  
+
 jobs:
   build_test_pack:
     name: Build, test & push image
@@ -23,9 +23,11 @@ jobs:
       IMAGE_NAME:  ${{ github.repository }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v1
-      - name: Setup .NET Core @ Latest
-        uses: actions/setup-dotnet@v1
+        uses: actions/checkout@v3
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: '7.0.x'
       - name: Restore
         run: dotnet restore
       - name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -180,3 +180,4 @@ sample/AlloyMvcTemplate/App_Data/**
 sample/AlloyMvcTemplate/App_Code/**
 /nupkgs
 /modules
+.idea

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,7 +2,7 @@
   <Import Project="build\version.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
     <LangVersion>latest</LangVersion>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,9 +2,8 @@
   <Import Project="build\version.props" />
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
-    <LangVersion>9.0</LangVersion>
-    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <LangVersion>latest</LangVersion>
     <WarnOnPackingNonPackableProject>false</WarnOnPackingNonPackableProject>
     <EnableNETAnalyzers>true</EnableNETAnalyzers>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>

--- a/build/dependencies.props
+++ b/build/dependencies.props
@@ -1,14 +1,15 @@
 <Project>
   <PropertyGroup>
-    <CmsVersion>12.5.0</CmsVersion>
-    <CmsUiCoreVersion>[12.5.0,13)</CmsUiCoreVersion>
+    <CmsVersion>[12.17.1,13)</CmsVersion>
+    <CmsCoreVersion>[12.13.1,13)</CmsCoreVersion>
+    <CmsUiCoreVersion>[12.17.1,13)</CmsUiCoreVersion>
     <Lucene>4.8.0-beta00015</Lucene>
   </PropertyGroup>
   <ItemGroup Condition = "'$(TargetFramework)' != 'net461'">
     <PackageReference Update="EPiServer.CMS" Version="$(CmsVersion)" />
-    <PackageReference Update="EPiServer.Hosting" Version="$(CmsUiCoreVersion)" />
+    <PackageReference Update="EPiServer.Hosting" Version="$(CmsCoreVersion)" />
     <PackageReference Update="EPiServer.CMS.UI.Core" Version="$(CmsUiCoreVersion)" />
-    <PackageReference Update="EPiServer.CMS.AspNetCore.Templating" Version="$(CmsUiCoreVersion)" />
-    <PackageReference Update="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="$(CmsUiCoreVersion)" />
+    <PackageReference Update="EPiServer.CMS.AspNetCore.Templating" Version="$(CmsCoreVersion)" />
+    <PackageReference Update="EPiServer.CMS.AspNetCore.HtmlHelpers" Version="$(CmsCoreVersion)" />
   </ItemGroup>
 </Project>

--- a/build/version.props
+++ b/build/version.props
@@ -1,7 +1,7 @@
 <!-- This file may be overwritten by automation. Only values allowed here are VersionPrefix and VersionSuffix.  -->
 <Project>
   <PropertyGroup>
-    <VersionPrefix>10.0.0</VersionPrefix>
+    <VersionPrefix>10.1.0</VersionPrefix>
     <VersionSuffix>
     </VersionSuffix>
   </PropertyGroup>

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
       ASPNETCORE_ENVIRONMENT: Production
 
     ports:
-      - 5997:80
+      - 5000:80
     image: episerver.search.indexingservice:latest
     container_name: EPiServer.Search.IndexingService
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -4,15 +4,15 @@ services:
   search:
     build:
       dockerfile: ./src/EPiServer.Search.IndexingService/Search.Dockerfile
-      context: . 
+      context: .
     environment:
       ASPNETCORE_URLS: http://*:80
       ASPNETCORE_ENVIRONMENT: Production
-      
+
     ports:
-      - 5000:80
+      - 5997:80
     image: episerver.search.indexingservice:latest
-    container_name: EPiServer.Search.IndexingService 
+    container_name: EPiServer.Search.IndexingService
     volumes:
       - shared-folder:/app/App_Data
 

--- a/global.json
+++ b/global.json
@@ -1,7 +1,7 @@
 {
   "sdk": {
-     "version": "6.0.100",
-     "architecture": "x64",
-     "rollForward": "minor"
+    "version": "7.0.0",
+    "rollForward": "latestMajor",
+    "allowPrerelease": false
   }
 }

--- a/sample/AlloyMvcTemplate/AlloyMvcTemplates.csproj
+++ b/sample/AlloyMvcTemplate/AlloyMvcTemplates.csproj
@@ -1,15 +1,14 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
-  
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
     <NoWarn>NU5100</NoWarn>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="BuildBundlerMinifier" Version="3.2.449" />
     <PackageReference Include="Wangkanai.Detection" Version="2.0.1" />
-    <PackageReference Include="Serilog" Version="2.10.0" />
-    <PackageReference Include="Serilog.AspNetCore" Version="3.4.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="4.1.0" />
+    <PackageReference Include="Serilog" Version="2.12.0" />
+    <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="EPiServer.CMS" />
     <PackageReference Include="EPiServer.Hosting" />
     <PackageReference Include="EPiServer.CMS.AspNetCore.HtmlHelpers" />

--- a/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
+++ b/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
@@ -9,7 +9,7 @@
     <EmbeddedResource Include="Resources\language.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EPiServer.CMS.UI.Core" Version="12.9.3" />
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="12.13.2"  />
+    <PackageReference Include="EPiServer.CMS.UI.Core" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" />
   </ItemGroup>
 </Project>

--- a/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
+++ b/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
@@ -1,8 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
-  <Import Project="$(BuildDirectory)public.props" />
   <ItemGroup>
     <None Remove="Resources\language.xml" />
   </ItemGroup>
@@ -10,7 +9,7 @@
     <EmbeddedResource Include="Resources\language.xml" />
   </ItemGroup>
   <ItemGroup>
-    <PackageReference Include="EPiServer.CMS.UI.Core" />
-    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" />
+    <PackageReference Include="EPiServer.CMS.UI.Core" Version="12.9.3" />
+    <PackageReference Include="EPiServer.CMS.AspNetCore.Templating" Version="12.13.2"  />
   </ItemGroup>
 </Project>

--- a/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
+++ b/src/EPiServer.Search.Cms/EPiServer.Search.Cms.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Razor">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <None Remove="Resources\language.xml" />

--- a/src/EPiServer.Search.Cms/Job/IndexingJob.cs
+++ b/src/EPiServer.Search.Cms/Job/IndexingJob.cs
@@ -1,3 +1,5 @@
+using System;
+using EPiServer.Core;
 using EPiServer.DataAbstraction;
 using EPiServer.PlugIn;
 using EPiServer.ServiceLocation;
@@ -31,7 +33,11 @@ namespace EPiServer.Job
         /// <summary>
         /// Executes the specified context.
         /// </summary>
-        public override string Execute() => _indexingJobService.Start(OnStatusChanged);
+        public override string Execute()
+        {
+            using var contentCacheScope = new ContentCacheScope { SlidingExpiration = TimeSpan.Zero };
+            return _indexingJobService.Start(OnStatusChanged);
+        }
 
         /// <summary>
         /// Stops the indexing job.

--- a/src/EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj
+++ b/src/EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj
@@ -1,13 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Lucene.Net" Version="4.8.0-beta00015"/>
-    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00015"/>
-    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00015"/>
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.4" />
+    <PackageReference Include="Lucene.Net" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.Analysis.Common" Version="4.8.0-beta00016" />
+    <PackageReference Include="Lucene.Net.QueryParser" Version="4.8.0-beta00016" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
   </ItemGroup>
 
 </Project>

--- a/src/EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj
+++ b/src/EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0</TargetFrameworks>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/EPiServer.Search.IndexingService/Search.Dockerfile
+++ b/src/EPiServer.Search.IndexingService/Search.Dockerfile
@@ -1,8 +1,8 @@
-FROM mcr.microsoft.com/dotnet/aspnet:6.0-bullseye-slim AS base
+FROM mcr.microsoft.com/dotnet/aspnet:7.0-bullseye-slim AS base
 WORKDIR /app
 EXPOSE 8000
 
-FROM mcr.microsoft.com/dotnet/sdk:6.0-bullseye-slim AS build
+FROM mcr.microsoft.com/dotnet/sdk:7.0-bullseye-slim AS build
 WORKDIR /src
 COPY ["src/EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj", "EPiServer.Search.IndexingService/"]
 RUN dotnet restore "EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj"
@@ -11,7 +11,7 @@ COPY ["src/EPiServer.Search.IndexingService/", "EPiServer.Search.IndexingService
 RUN dotnet build "EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj" -c Release -o /app/build
 
 FROM build AS publish
-RUN dotnet publish "EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj" -c Release -o /app/publish
+RUN dotnet publish "EPiServer.Search.IndexingService/EPiServer.Search.IndexingService.csproj" -c Release -o /app/publish --framework net7.0
 
 FROM base AS final
 WORKDIR /app

--- a/test/EPiServer.Search.Cms.Test/Core/ContentSearchHandlerTests.cs
+++ b/test/EPiServer.Search.Cms.Test/Core/ContentSearchHandlerTests.cs
@@ -100,7 +100,7 @@ namespace EPiServer.Core
         public void UpdateItem_WhenContentIsProvided_ShouldUseContentGuidAndLanguageAsId()
         {
             var sharedBlockCreator = new SharedBlockFactory(null, new ConstructorParameterResolver(),
-                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))));
+                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))), _contentTypeRepositoryMock.Object);
             _testSubject.ServiceActive = true;
 
             var block = sharedBlockCreator.CreateSharedBlock(typeof(BlockData));
@@ -119,7 +119,7 @@ namespace EPiServer.Core
         public void UpdateItem_WhenContentIsProvided_ShouldUseNameAsTitle()
         {
             var sharedBlockCreator = new SharedBlockFactory(null, new ConstructorParameterResolver(),
-                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))));
+                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))), _contentTypeRepositoryMock.Object);
             _testSubject.ServiceActive = true;
 
             var block = sharedBlockCreator.CreateSharedBlock(typeof(BlockData));
@@ -427,7 +427,7 @@ namespace EPiServer.Core
         public void GetSearchResult_WhenQueryIsExecuted_ContentQueryShouldBeAdded()
         {
             var sharedBlockCreator = new SharedBlockFactory(null, new ConstructorParameterResolver(),
-                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))));
+                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))), _contentTypeRepositoryMock.Object);
             var content = sharedBlockCreator.CreateSharedBlock(typeof(BlockData));
             content.ContentLink = new ContentReference(1);
             _contentRepositoryMock.Setup(r => r.Get<IContent>(It.IsAny<ContentReference>())).Returns(content);
@@ -456,7 +456,7 @@ namespace EPiServer.Core
                 .Callback<AccessControlListQuery, IPrincipal, object>((q, p, o) => { q.AddUser(p.Identity.Name); });
 
             var sharedBlockCreator = new SharedBlockFactory(null, new ConstructorParameterResolver(),
-                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))));
+                new ServiceLocation.ServiceAccessor<ContentDataInterceptor>(() => new ContentDataInterceptor(new ContentDataInterceptorHandler(new ConstructorParameterResolver()))), _contentTypeRepositoryMock.Object);
             var content = sharedBlockCreator.CreateSharedBlock(typeof(BlockData));
             content.ContentLink = new ContentReference(1);
             _contentRepositoryMock.Setup(r => r.Get<IContent>(It.IsAny<ContentReference>())).Returns(content);

--- a/test/EPiServer.Search.Cms.Test/EPiServer.Search.Cms.Test.csproj
+++ b/test/EPiServer.Search.Cms.Test/EPiServer.Search.Cms.Test.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/EPiServer.Search.Cms.Test/EPiServer.Search.Cms.Test.csproj
+++ b/test/EPiServer.Search.Cms.Test/EPiServer.Search.Cms.Test.csproj
@@ -1,20 +1,20 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/test/EPiServer.Search.IndexingService.Test/EPiServer.Search.IndexingService.Test.csproj
+++ b/test/EPiServer.Search.IndexingService.Test/EPiServer.Search.IndexingService.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/test/EPiServer.Search.IndexingService.Test/EPiServer.Search.IndexingService.Test.csproj
+++ b/test/EPiServer.Search.IndexingService.Test/EPiServer.Search.IndexingService.Test.csproj
@@ -7,15 +7,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="5.0.4" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
-    <PackageReference Include="Moq" Version="4.16.1" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
+    <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.5.0" />
+    <PackageReference Include="Moq" Version="4.17.2" />
+    <PackageReference Include="xunit" Version="2.4.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="1.3.0">
+    <PackageReference Include="coverlet.collector" Version="3.2.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
Hi 🙂 

In this PR I would like to bring following changes to `content-search-lucene`:
* Bring `Episerver` dependencies up to latest versions (`12.13.1`/`12.17.1`)
* Target `IndexingService` to `.NET 7`
* Set `ContentCacheScope` for `IndexingJob` to reduce memory consumption for larger project
* Set SDK to 7.0
* Build Docker image with .NET 7 by default
* Minor updates to test packages

I plan to bring more memory optimizations also for data collecting in `IndexingJob` / `ContentSearchHandlerImplementation` , but in a separate PR, if this will be approved and merged.

--- 
Duplicate of #23, we're trying to resolve issues with building package.